### PR TITLE
Moved mocha to devDependencies and upgraded to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/riichard/boolean-parser-js/issues"
   },
   "homepage": "https://github.com/riichard/boolean-parser-js",
-  "dependencies": {
-    "mocha": "^2.3.4"
+  "devDependencies": {
+    "mocha": "^3.1.0"
   }
 }


### PR DESCRIPTION
Thank you for a very nice module!

Since mocha only needs to be installed when running tests it should not be installed when boolean-parser.js is pulled in as a dependency. As such mocha should be placed in devDependencies in package.json.
Also the version of mocha gives a lot of warnings of using old packages, tests seems to run fin with a later version of mocha so the version was stepped.
